### PR TITLE
drop udev and trigger wl1251 using openrc instead

### DIFF
--- a/49-firmware-wl1251.rules
+++ b/49-firmware-wl1251.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="firmware", ACTION=="add", ENV{FIRMWARE}=="*wl1251-nvs.bin", RUN:="/usr/bin/wl1251-wrap /usr/bin/wl1251-cal --nvs-loading=/sys$env{DEVPATH}/loading --nvs-push-data=/sys$env{DEVPATH}/data"

--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,14 @@ wl1251-cal: wl1251-cal.c
 
 install:
 	install -d "$(DESTDIR)/usr/bin"
-	install -m 755 wl1251-wrap "$(DESTDIR)/usr/bin"
 	install -m 755 wl1251-cal "$(DESTDIR)/usr/bin"
-ifeq ($(WITH_UPSTART), 1)
-	install -d "$(DESTDIR)/etc/event.d"
-	install -m 644 script/wl1251-cal "$(DESTDIR)/etc/event.d"
-endif
-ifeq ($(WITH_UDEV), 1)
-	install -d "$(DESTDIR)/lib/udev/rules.d"
-	install -m 644 49-firmware-wl1251.rules "$(DESTDIR)/lib/udev/rules.d"
+	install -m 755 wl1251-extract-nvs "$(DESTDIR)/usr/bin"
+	install -d "$(DESTDIR)/etc/modprobe.d"
+	install -m 644 wl1251-blacklist.conf "$(DESTDIR)/etc/modprobe.d"
+
+ifeq ($(WITH_OPENRC), 1)
+	install -d "$(DESTDIR)/etc/init.d"
+	install -m 644 script/wl1251-cal "$(DESTDIR)/etc/init.d"
 endif
 
 clean:

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Standards-Version: 3.7.2
 Package: wl1251-cal
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: calibration data pusher for wl1251
- This application reads the stored calibration data and pushes it to wl1251.
+Description: calibration data extractor for wl1251
+ This application reads the stored calibration data and stores it in /lib/firmware.

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,8 +2,10 @@
 
 set -e
 
-dpkg-divert --add --package wl1251-cal \
-	--divert /lib/firmware/ti-connectivity/wl1251-nvs.bin.disabled \
-	--rename /lib/firmware/ti-connectivity/wl1251-nvs.bin
+if dpkg-divert --list | grep -F "wl1251-nvs.bin"
+then
+        dpkg-divert --remove --package wl1251-cal \
+        --no-rename /lib/firmware/ti-connectivity/wl1251-nvs.bin
+fi
 
-udevadm control --reload-rules && udevadm trigger
+rc-update add wl1251-cal sysinit

--- a/debian/postrm
+++ b/debian/postrm
@@ -2,7 +2,10 @@
 
 set -e
 
-dpkg-divert --remove --package wl1251-cal \
-	--rename /lib/firmware/ti-connectivity/wl1251-nvs.bin
+if dpkg-divert --list | grep -F "wl1251-nvs.bin"
+then
+        dpkg-divert --remove --package wl1251-cal \
+        --no-rename /lib/firmware/ti-connectivity/wl1251-nvs.bin
+fi
 
 udevadm control --reload-rules && udevadm trigger

--- a/debian/rules
+++ b/debian/rules
@@ -4,8 +4,7 @@ export WITH_DBUS=1
 export WITH_LIBCAL=1
 export WITH_LIBNL3=1
 export WITH_WL1251_NL=1
-export WITH_UPSTART=0
-export WITH_UDEV=1
+export WITH_OPENRC=1
 
 %:
 	dh $@

--- a/script/wl1251-cal
+++ b/script/wl1251-cal
@@ -1,10 +1,15 @@
-description "wl1251-cal"
+#!/sbin/openrc-run
+description="Extract wl1251 nvs from CAL and write it to /lib/firmware"
 
-start on TEST
-start on LOCAL
+depend()
+{
+        before networking
+}
 
-pre-start script
-        modprobe wl12xx||true
-end script
-
-exec /usr/bin/wl1251-cal
+start()
+{
+        wl1251-extract-nvs
+        # probe wl1251 once the nvs is ready
+        modprobe wl1251_spi
+        eend $?
+}

--- a/wl1251-blacklist.conf
+++ b/wl1251-blacklist.conf
@@ -1,0 +1,3 @@
+# Ensure wl1251 does not load until wl1251-cal has been run
+blacklist wl1251_spi
+blacklist wl1251

--- a/wl1251-extract-nvs
+++ b/wl1251-extract-nvs
@@ -1,0 +1,2 @@
+#!/bin/sh
+wl1251-cal --nvs-loading=/dev/null --nvs-push-data=/lib/firmware/ti-connectivity/wl1251-nvs.bin

--- a/wl1251-wrap
+++ b/wl1251-wrap
@@ -1,4 +1,0 @@
-#!/bin/sh
-# This is a wrapper for wl1251-cal for use with udev.
-
-$@ 2>&1 >/dev/null


### PR DESCRIPTION
udev no longer supports delegating firmware loading to a userspace script [1]. So use openrc to trigger the extraction of nvs from CAL. To ensure this happens before the driver has loaded, blacklist the driver, and load it from the script once nvs processing has completed.

[1] https://github.com/eudev-project/eudev/commit/3b717594600fa717cdf9bcfd0c7c1b703b245482

Somewhat depends on https://github.com/maemo-leste/leste-config/pull/56